### PR TITLE
Some little changes

### DIFF
--- a/bfcore.rb
+++ b/bfcore.rb
@@ -10,6 +10,24 @@ class BFCore
   def gen_prologue(data)
     g = @g
 
+    g.comment('interpreter check')
+
+    # Test for cell wrap != 256
+    g.emit '>[-]<[-]++++++++[>++++++++<-]>[<++++>-]<[>>'
+
+    # Print message 'Sorry this program needs an 8bit interpreter\n'
+    g.emit '>++++[<++++>-]<+[>++++++>+++++++>++>+++>+++++<<<<<-]>>>>>--.<<<-'
+    g.emit '-------.+++..+++++++.>--.<-----.<++.+.>-.>.<---.++.---.<--.>+++.'
+    g.emit '<------.>-----.>.<+.<++++..-.>+++++.>.<<---.>-----.>.>+++++.<<<+'
+    g.emit '.>-----.+++++++++++.>.<<+++++++.+++++.>.<---------.>--.--.++.<.>'
+    g.emit '++.<.>--.<<++++++++++.'
+
+    # endif
+    g.emit '<<[-]]'
+
+    # Test for cell wrap != 256 and flip condition
+    g.emit '>[-]<[-]++++++++[>++++++++<-]>[<++++>-]+<[>-<[-]]>[-<'
+
     g.comment('init data')
     data.each do |d, i|
       raise if i > 65535
@@ -143,6 +161,11 @@ class BFCore
     g.comment('epilogue')
     g.move_ptr(RUNNING)
     g.emit ']'
+
+    # endif for cell size check. (should be [-]] but we already have a zero)
+    g.emit ']'
+    # EOL at EOF
+    g.comment('[...THE END...]')
   end
 
 end

--- a/bfgen.rb
+++ b/bfgen.rb
@@ -78,6 +78,8 @@ class BFGen
 
   def add(ptr, v)
     move_ptr(ptr)
+    v = v % 256
+    v = v - 256 if v > 127
     emit v > 0 ? '+' * v : '-' * -v
   end
 

--- a/bfgen.rb
+++ b/bfgen.rb
@@ -6,12 +6,22 @@ class BFGen
   end
 
   def emit(s)
-    @started = true
-    print s
+    @colno = 0 if @colno == nil
+    while s.length > 0 do
+	if @colno + s.length >= 80
+	    puts s.slice!(0, 80-@colno)
+	    @colno = 0
+	else
+	    print s
+	    @colno = @colno + s.length
+	    return
+	end
+    end
   end
 
   def comment(s)
-    puts if @started
+    puts if @colno && @colno > 0
+    @colno = 0
     puts "# #{s}"
   end
 

--- a/test/copy_struct.c
+++ b/test/copy_struct.c
@@ -17,4 +17,5 @@ int main() {
   S* s4 = malloc(sizeof(S));
   *s4 = s1;
   printf("%d %d %d\n", s4->x, s4->y, s4->z);
+  return 0;
 }

--- a/test/global_struct_ref.c
+++ b/test/global_struct_ref.c
@@ -10,4 +10,5 @@ S* struct_ptr = &(S){ .x = 42, .y = 43, .z = 44 };
 
 int main() {
   printf("%d %d %d\n", struct_ptr->x, struct_ptr->y, struct_ptr->z);
+  return 0;
 }

--- a/test/mem.bfs
+++ b/test/mem.bfs
@@ -2,6 +2,12 @@ mov b, 77
 store b, 300
 load a, 300
 putc a
+mov b, 69
+store b, 30
+load a, 30
+putc a
+add a, 8
+putc a
 load a, 556
 add a, 10
 putc a

--- a/test/printf.c
+++ b/test/printf.c
@@ -8,4 +8,5 @@ int main() {
   printf("%s %d\n", buf, n);
   n = snprintf(buf, 3, "hogefuga");
   printf("%s %d\n", buf, n);
+  return 0;
 }


### PR DESCRIPTION
Each of the commits is an independent fix or update.
- Cell size error: gives a simple message if the interpreter isn't 8bit. Rather than random weirdness.
- C99: a C99 compiler returns 0 from main if it's not defined, but the files aren't compiled as c99 by default gcc.
- Signed chars: on an 8bit interpreter it's smaller to go negative for numbers over 128.
- Wrapping the BF at 80 columns looks neater.
- A test for memory locations below 256; the remains of my version of your recent fix.
